### PR TITLE
OBK-69: Adds error marker to tabs

### DIFF
--- a/src/components/NotificationSnackBar.tsx
+++ b/src/components/NotificationSnackBar.tsx
@@ -7,16 +7,29 @@ type Notification = {
   severity?: AlertColor,
 };
 
+type NotificationState = {
+  notification?: Notification,
+  isOpen: boolean,
+}
+
 export function useNotifications() {
-  const [current, setCurrentNotification] = useState<Notification>({});
+  const [current, setCurrentNotification] = useState<NotificationState>({
+    isOpen: false,
+  });
 
   return {
     show: (notification: Notification) => {
-      setCurrentNotification(notification);
+      setCurrentNotification({
+        notification,
+        isOpen: true,
+      });
     },
 
     close: () => {
-      setCurrentNotification({});
+      setCurrentNotification((value) => ({
+        notification: value.notification,
+        isOpen: false,
+      }));
     },
 
     current: current,
@@ -24,18 +37,18 @@ export function useNotifications() {
 }
 
 export type NotificationSnackBarProps = {
-  currentNotification: Notification,
+  currentNotification: NotificationState,
   closeNotification: () => void,
 };
 
 export default function NotificationSnackBar({currentNotification, closeNotification}: NotificationSnackBarProps) {
   return (
-    <Snackbar open={!!currentNotification.message} onClose={closeNotification} autoHideDuration={5000}>
+    <Snackbar open={currentNotification.isOpen} onClose={closeNotification} autoHideDuration={5000}>
       <Alert
-        severity={currentNotification.severity}
+        severity={currentNotification.notification?.severity}
         variant="filled"
         onClose={closeNotification}>
-        {currentNotification.message}
+        {currentNotification.notification?.message}
       </Alert>
     </Snackbar>
   );

--- a/src/components/TabbedSections.tsx
+++ b/src/components/TabbedSections.tsx
@@ -4,6 +4,7 @@ import { TabsProps } from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import { Box } from "@mui/material";
 import { BoxProps } from "@mui/material";
+import ErrorOutline from '@mui/icons-material/ErrorOutline';
 
 export type TabbedSectionsProps = {
   initialTab?: number,
@@ -11,6 +12,7 @@ export type TabbedSectionsProps = {
   sections: {
     key: string,
     label: string,
+    hasError?: boolean,
     component: React.ReactNode,
   }[],
 
@@ -30,7 +32,11 @@ export default function TabbedSections(props: TabbedSectionsProps) {
     <>
       <Tabs {...props.tabProps} value={currentTab} onChange={handleChangeCurrentTab}>
         {props.sections.map((section) => (
-          <Tab key={`${section.key}-tab`} label={section.label} />
+          <Tab 
+            key={`${section.key}-tab`} 
+            icon={section.hasError ? <ErrorOutline color="error"/> : undefined}
+            iconPosition="start"
+            label={section.label} />
         ))}
       </Tabs>
 

--- a/src/routes/cases/components/AggressorFields.tsx
+++ b/src/routes/cases/components/AggressorFields.tsx
@@ -10,6 +10,13 @@ import  {
     allCaseVictimBondsAggressor,
 } from "../formValues";
 
+// This list exposes which fields that actually belong to the case are being
+// displayed here, in order to be able to track errors for the component
+export const controlledFields = new Set([
+    "victimBondAggressor",
+    ...Object.getOwnPropertyNames(defaultFormValues.aggressor).map((field) => `aggressor.${field}`),
+]);
+
 const AggressorFields = withForm({
     defaultValues: defaultFormValues,
     render: function Render({form}) {

--- a/src/routes/cases/components/CaseFields.tsx
+++ b/src/routes/cases/components/CaseFields.tsx
@@ -1,5 +1,7 @@
 import { withForm } from "@/hooks/form";
 import Grid from "@mui/material/Grid";
+import { controlledFields as aggressorControlledFields } from "./AggressorFields";
+import { controlledFields as victimControlledFields } from "./VictimFields";
 import {
   defaultFormValues,
   allMomentsOfDay,
@@ -9,6 +11,13 @@ import {
   allCaseMurderWeapons,
   allCaseCategories,
 } from "../formValues";
+
+// This list exposes which fields that actually belong to the case are being
+// displayed here, in order to be able to track errors for the component
+export const controlledFields = new Set(Object.getOwnPropertyNames(defaultFormValues))
+  .difference(new Set(["victim", "aggressor"]))
+  .difference(aggressorControlledFields)
+  .difference(victimControlledFields);
 
 const CaseFields = withForm({
   defaultValues: defaultFormValues,
@@ -54,9 +63,6 @@ const CaseFields = withForm({
             )}
 
           />
-
-
-
 
           <Grid item xs={12} sm={6}>
             <form.AppField

--- a/src/routes/cases/components/CaseForm.tsx
+++ b/src/routes/cases/components/CaseForm.tsx
@@ -1,13 +1,14 @@
 import NotificationSnackBar, {useNotifications} from "@/components/NotificationSnackBar";
 import TabbedSections from "@/components/TabbedSections";
 import {handleFormSubmit, setErrorMapFromValidationResponse, useAppForm} from "@/hooks/form";
-import AggressorFields from "@/routes/cases/components/AggressorFields";
-import CaseFields from "@/routes/cases/components/CaseFields";
-import VictimFields from "@/routes/cases/components/VictimFields";
+import AggressorFields, { controlledFields as aggressorSectionFields } from "@/routes/cases/components/AggressorFields";
+import CaseFields, { controlledFields as caseControlledFields } from "@/routes/cases/components/CaseFields";
+import VictimFields, { controlledFields as victimSectionFields } from "@/routes/cases/components/VictimFields";
 import {defaultFormValues} from "@/routes/cases/formValues";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import {CaseValidationResult} from "@/api/aqsnv/cases";
+import { useStore } from "@tanstack/react-form";
 
 export type CaseFormProps = {
     defaultValues: typeof defaultFormValues,
@@ -43,6 +44,14 @@ export default function CaseForm({defaultValues, onSubmit, reset}: CaseFormProps
         },
     });
 
+    const fieldsWithErrors = useStore(
+        form.store, 
+        (state) => Object
+            .entries(state.fieldMeta)
+            .filter(([, meta]) => !meta.isValid)
+            .map(([field]) => field)
+    );
+
     return (
         <Container maxWidth="md">
             <form onSubmit={handleFormSubmit(form)} noValidate>
@@ -58,17 +67,20 @@ export default function CaseForm({defaultValues, onSubmit, reset}: CaseFormProps
                         {
                             key: "case",
                             label: "Información del Caso",
-                            component: <CaseFields form={form} />
+                            component: <CaseFields form={form} />,
+                            hasError: fieldsWithErrors.some((field) => caseControlledFields.has(field))
                         },
                         {
                             key: "victim",
                             label: "Víctima",
-                            component: <VictimFields form={form} />
+                            component: <VictimFields form={form} />,
+                            hasError: fieldsWithErrors.some((field) => victimSectionFields.has(field)),
                         },
                         {
                             key: "aggressor",
                             label: "Agresor",
-                            component: <AggressorFields form={form} />
+                            component: <AggressorFields form={form} />,
+                            hasError: fieldsWithErrors.some((field) => aggressorSectionFields.has(field)),
                         },
                     ]}
                 />

--- a/src/routes/cases/components/VictimFields.tsx
+++ b/src/routes/cases/components/VictimFields.tsx
@@ -8,6 +8,17 @@ import {
     allCaseJudicialMeasures,
 } from "../formValues";
 
+// This list exposes which fields that actually belong to the case are being
+// displayed here, in order to be able to track errors for the component
+export const controlledFields = new Set([
+    "isRape",
+    "hadLegalComplaints",
+    "wasJudicialized",
+    "totalLegalComplaints",
+    "judicialMeasures",
+    ...Object.getOwnPropertyNames(defaultFormValues.victim).map((field) => `victim.${field}`),
+]);
+
 const VictimFields = withForm({
     defaultValues: defaultFormValues,
     render: function Render({ form }) {
@@ -97,7 +108,6 @@ const VictimFields = withForm({
                             </Grid>
                         )}
                     />
-
 
                     <Grid item xs={12} sm={6}>
                         <form.AppField

--- a/src/routes/cases/formValues.tsx
+++ b/src/routes/cases/formValues.tsx
@@ -44,7 +44,7 @@ export const defaultFormValues = {
     victim: {
         fullName: "",
         age: "",
-        gender: Gender.MUJER as string,
+        gender: Gender.MUJER as string | null,
         nationality: null as string | null,
         isSexualWorker: false,
         isMissingPerson: false,
@@ -60,7 +60,7 @@ export const defaultFormValues = {
     aggressor: {
         fullName: "",
         age: "",
-        gender: Gender.HOMBRE as string,
+        gender: Gender.HOMBRE as string | null,
         hasLegalComplaintHistory: false,
         hasPreviousCases: false,
         wasInPrison: false,
@@ -183,7 +183,7 @@ function victimToVictimValues(value: Victim): typeof defaultFormValues.victim {
     return {
         fullName: value.fullName || "",
         age: value.age?.toString() || "",
-        gender: value.gender || "",
+        gender: value.gender || null,
         nationality: value.nationality || null,
         isSexualWorker: value.isSexualWorker || false,
         isMissingPerson: value.isMissingPerson || false,
@@ -201,7 +201,7 @@ function aggressorToAggressorValues(value: Aggressor): typeof defaultFormValues.
     return {
         fullName: value.fullName || "",
         age: value.age?.toString() || "",
-        gender: value.gender || "",
+        gender: value.gender || null,
         hasLegalComplaintHistory: value.hasLegalComplaintHistory || false,
         hasPreviousCases: value.hasPreviousCases || false,
         wasInPrison: value.wasInPrison || false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
See https://ahoraquesinosven.atlassian.net/browse/OBK-69

Cambios:

* Las notificaciones ahora se manejan con un flag para prender y apagar, además de los settings que antes estaban en la notificación. Esto es para evitar un error que se daba antes que mostraba por algunos segundos una notificación vacía cuando se daba el close.
* Íconos de error en los tabas cuando un campo del tab tiene error.
* Arregla el error de tener que limpiar los géneros de víctima y agresor en el edit.